### PR TITLE
Fix description package build error

### DIFF
--- a/whill/package.xml
+++ b/whill/package.xml
@@ -14,6 +14,7 @@
   <exec_depend>whill_driver</exec_depend>
   <exec_depend>whill_bringup</exec_depend>
   <exec_depend>whill_examples</exec_depend>
+  <exec_depend>whill_description</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/whill_description/CMakeLists.txt
+++ b/whill_description/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.8)
+project(whill_description)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY urdf
+  DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/whill_description/README.md
+++ b/whill_description/README.md
@@ -2,7 +2,13 @@
 
 ## About
 
-The "whill_description" is a ROS2 package for descriptions of WHILL Model CR2. <br>
+The "whill_description" is a ROS2 package for descriptions of WHILL Model CR2.  
+
+To preview the URDF, run the following command:
+
+```
+ros2 launch urdf_tutorial display.launch.py model:="$(ros2 pkg prefix whill_description --share)/urdf/whill_model_cr2.urdf"
+```
 
 
 ## License

--- a/whill_description/package.xml
+++ b/whill_description/package.xml
@@ -6,4 +6,8 @@
   <description>WHILL Model CR2 description package</description>
   <maintainer email="george.mandokoro@whill.inc">George Mandokoro</maintainer>
   <license>MIT</license>
+  <exec_depend>urdf</exec_depend>
+  <export>
+   <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/whill_driver/CMakeLists.txt
+++ b/whill_driver/CMakeLists.txt
@@ -30,7 +30,7 @@ ament_target_dependencies(whill
   std_msgs
   sensor_msgs
   geometry_msgs
- "whill_msgs"
+  whill_msgs
 )
 
 add_library(whill_node SHARED


### PR DESCRIPTION
下記のようにcolcon build時にCMakeのエラーが出るので修正します。


```
Starting >>> whill_description
--- stderr: whill_description                                                         
CMake Warning:
  Ignoring extra path from command line:

   "/home/user/ros2_ws/src/ros2_whill/whill_description"


CMake Error: The source directory "/home/user/ros2_ws/src/ros2_whill/whill_description" does not appear to contain CMakeLists.txt.
```