### PR TITLE
Fix install path

### DIFF
--- a/whill_bringup/launch/whill_launch.py
+++ b/whill_bringup/launch/whill_launch.py
@@ -7,6 +7,7 @@ from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node
 
+
 def generate_launch_description():
     return LaunchDescription([
         Node(
@@ -14,6 +15,6 @@ def generate_launch_description():
             namespace='',
             executable='whill',
             name='whill',
-            parameters=[PathJoinSubstitution([FindPackageShare('whill_bringup'), 'params.yaml'])],
+            parameters=[PathJoinSubstitution([FindPackageShare('whill_bringup'), 'config', 'params.yaml'])],
         ),
     ])

--- a/whill_bringup/setup.py
+++ b/whill_bringup/setup.py
@@ -1,3 +1,6 @@
+from glob import glob
+import os
+
 from setuptools import find_packages, setup
 
 package_name = 'whill_bringup'
@@ -9,9 +12,9 @@ setup(
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
-        ('share/' + package_name, ['package.xml']),
-        ('share/' + package_name, ['launch/whill_launch.py']),
-        ('share/' + package_name, ['config/params.yaml']),
+        (os.path.join('share', package_name), ['package.xml']),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
+        (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/whill_examples/launch/whill_examples_launch.py
+++ b/whill_examples/launch/whill_examples_launch.py
@@ -7,6 +7,7 @@ from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node
 
+
 def generate_launch_description():
     return LaunchDescription([
         Node(
@@ -14,7 +15,7 @@ def generate_launch_description():
             namespace='',
             executable='whill',
             name='whill',
-            parameters=[PathJoinSubstitution([FindPackageShare('whill_examples'), 'params.yaml'])],
+            parameters=[PathJoinSubstitution([FindPackageShare('whill_examples'), 'config', 'params.yaml'])],
         ),
         Node(
             package='whill_examples',

--- a/whill_examples/setup.py
+++ b/whill_examples/setup.py
@@ -1,3 +1,6 @@
+from glob import glob
+import os
+
 from setuptools import find_packages, setup
 
 package_name = 'whill_examples'
@@ -9,9 +12,9 @@ setup(
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
-        ('share/' + package_name, ['package.xml']),
-        ('share/' + package_name, ['launch/whill_examples_launch.py']),
-        ('share/' + package_name, ['config/params.yaml']),
+        (os.path.join('share', package_name), ['package.xml']),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
+        (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
現状の設定だと`install/$PACKEGE_NAME/share/$PACKEGE_NAME`にlaunch.pyやconfig.yamlが直接配置されます。

これをament_cmakeで設定する場合と同様に`launch`や`config`ディレクトリの下に配置するように変更します。
これにより他のパッケージのlaunchファイルからwhill_bringupのwhill_launch.pyをincludeしやすくします。


```python
    whill_driver_launch = IncludeLaunchDescription(
        PythonLaunchDescriptionSource(
            [
                # 現状はこちらでincludeできる
                os.path.join(get_package_share_directory('whill_bringup'),
                             'whill_launch.py'),
                # ament_cmakeの場合はこちらなので、本PRでこちらに統一する
                os.path.join(get_package_share_directory('whill_bringup'), 'launch',
                             'whill_launch.py'),
            ]
        ),
    )
```

インストール先before

`install/whill_bringup/share/whill_bringup/whill_launch.py`


インストール先after

`install/whill_bringup/share/whill_bringup/launch/whill_launch.py`