### PR TITLE
[Model CR] Port Crystal features (Odom, etc.) to Humble & Add cmd_vel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ add_executable(whill_modelc_controller
 
 ament_target_dependencies(whill_modelc_controller
 	"rclcpp"
+	"sensor_msgs"
+	"geometry_msgs"
 	"ros2_whill_interfaces"
 )
 
@@ -75,6 +77,7 @@ target_link_libraries(whill_modelc_controller
 	${rmw_implementation_LIBRARIES}
 	${std_msgs_LIBRARIES}
 	${sensor_msgs_LIBRARIES}
+	${geometry_msgs_LIBRARIES}
 	${ros2_whill_interfaces_LIBRARIES}
 )
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ ROS2 package for WHILL Model CR
 ### Subscribed Topics
 
 #### /whill/controller/joy [(sensor_msgs/Joy)](http://docs.ros.org/api/sensor_msgs/html/msg/Joy.html)
-- Virtual WHILL joystick input. You can controll WHILL via this topic.
+- Virtual WHILL joystick input. You can control WHILL via this topic.
+- `axes[0]`: Side direction (-1.0 to 1.0, negative = right)
+- `axes[1]`: Front direction (-1.0 to 1.0, positive = forward)
+
+#### /whill/controller/cmd_vel [(geometry_msgs/Twist)](http://docs.ros.org/api/geometry_msgs/html/msg/Twist.html)
+- Standard ROS velocity command. You can control WHILL via this topic.
+- `linear.x`: Forward velocity in m/s (max ~1.66 m/s)
+- `angular.z`: Angular velocity in rad/s (max ~0.83 rad/s, positive = counter-clockwise)
 
 
 ### Published Topics

--- a/package.xml
+++ b/package.xml
@@ -20,9 +20,15 @@
   <depend>rmw_implementation</depend>
   <depend>rclpy</depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>ros2_whill_interfaces</build_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>ros2_whill_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/src/odom.cpp
+++ b/src/odom.cpp
@@ -27,7 +27,7 @@ SOFTWARE.
 #include "sensor_msgs/msg/joint_state.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2_ros/transform_broadcaster.h"
 
 #include "./odom.h"

--- a/src/whill_modelc_controller.cpp
+++ b/src/whill_modelc_controller.cpp
@@ -32,6 +32,7 @@ Thus, it is no longer the recommended style for ROS 2.
 
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/joy.hpp"
+#include "geometry_msgs/msg/twist.hpp"
 
 #include "whill_modelc/com_whill.h"
 #include "ros2_whill_interfaces/srv/set_speed_profile.hpp"
@@ -170,8 +171,7 @@ bool set_battery_voltage_out_srv(
 }
 
 
-// Set Joystick
-
+// Set Joystick (from Joy message)
 void whillSetJoyMsgCallback(const sensor_msgs::msg::Joy::SharedPtr joy)
 {
     int joy_side  = -joy->axes[0] * 100.0f;
@@ -184,6 +184,37 @@ void whillSetJoyMsgCallback(const sensor_msgs::msg::Joy::SharedPtr joy)
     if(joy_side > 100)  joy_side = 100;
 
     sendJoystick(whill_fd, joy_front, joy_side);
+}
+
+// Set velocity (from Twist message)
+void whillSetCmdVelCallback(const geometry_msgs::msg::Twist::SharedPtr cmd_vel)
+{
+    // WHILL Model C specifications:
+    // - Maximum speed: approximately 1.66 m/s (measured from odometry)
+    // - Joy command range: -100 to 100
+    // - Wheel tread: approximately 0.496 m (based on CR2)
+    
+    // Convert linear velocity (m/s) to joy command (-100 to 100)
+    // joy_front = (linear_x / max_speed) * 100
+    const float MAX_LINEAR_SPEED = 1.66;  // m/s
+    int joy_front = (int)(cmd_vel->linear.x / MAX_LINEAR_SPEED * 100.0f);
+    
+    // Convert angular velocity (rad/s) to joy command (-100 to 100)
+    // For differential drive: linear_side = angular_z * wheel_tread / 2
+    // Estimated max angular velocity: approximately 0.83 rad/s
+    const float MAX_ANGULAR_SPEED = 0.83;  // rad/s
+    int joy_side = -(int)(cmd_vel->angular.z / MAX_ANGULAR_SPEED * 100.0f);
+    
+    // value check
+    if(joy_front < -100) joy_front = -100;
+    if(joy_front > 100)  joy_front = 100;
+    if(joy_side < -100) joy_side = -100;
+    if(joy_side > 100)  joy_side = 100;
+
+    sendJoystick(whill_fd, joy_front, joy_side);
+    
+    RCLCPP_DEBUG(node->get_logger(), "[CmdVel] linear: %.3f m/s, angular: %.3f rad/s -> joy_front: %d, joy_side: %d",
+                 cmd_vel->linear.x, cmd_vel->angular.z, joy_front, joy_side);
 }
 
 
@@ -206,7 +237,8 @@ int main(int argc, char **argv)
     auto set_battery_voltage_out = node->create_service<ros2_whill_interfaces::srv::SetBatteryVoltageOut>("/whill/set_battery_voltage_out_srv", set_battery_voltage_out_srv);
 
     // Subscribers
-    auto whill_setjoy_sub = node->create_subscription<sensor_msgs::msg::Joy>("/whill/controller/joy", whillSetJoyMsgCallback, rmw_qos_profile_sensor_data);
+    auto whill_setjoy_sub = node->create_subscription<sensor_msgs::msg::Joy>("/whill/controller/joy", rclcpp::SensorDataQoS(), whillSetJoyMsgCallback);
+    auto whill_setcmdvel_sub = node->create_subscription<geometry_msgs::msg::Twist>("/whill/controller/cmd_vel", rclcpp::SensorDataQoS(), whillSetCmdVelCallback);
 
     initializeComWHILL(&whill_fd, serialport);
     rclcpp::spin(node);

--- a/src/whill_modelc_publisher.cpp
+++ b/src/whill_modelc_publisher.cpp
@@ -148,16 +148,16 @@ int main(int argc, char **argv)
 	rclcpp::init(argc, argv);
 	node = rclcpp::Node::make_shared("whill_modelc_publisher");
 
-	auto whill_modelc_pub         = node->create_publisher<ros2_whill_interfaces::msg::WhillModelC>("/whill/modelc_state");
-	auto whill_modelc_joy         = node->create_publisher<sensor_msgs::msg::Joy>("/whill/states/joy");
-	auto whill_modelc_joint_state = node->create_publisher<sensor_msgs::msg::JointState>("/whill/states/joint_state");
-	auto whill_modelc_imu         = node->create_publisher<sensor_msgs::msg::Imu>("/whill/states/imu");
-	auto whill_modelc_battery     = node->create_publisher<sensor_msgs::msg::BatteryState>("/whill/states/batttery_state");
-	auto whill_modelc_odom        = node->create_publisher<nav_msgs::msg::Odometry>("/whill/odom");
+	auto whill_modelc_pub         = node->create_publisher<ros2_whill_interfaces::msg::WhillModelC>("/whill/modelc_state", 10);
+	auto whill_modelc_joy         = node->create_publisher<sensor_msgs::msg::Joy>("/whill/states/joy", 10);
+	auto whill_modelc_joint_state = node->create_publisher<sensor_msgs::msg::JointState>("/whill/states/joint_state", 10);
+	auto whill_modelc_imu         = node->create_publisher<sensor_msgs::msg::Imu>("/whill/states/imu", 10);
+	auto whill_modelc_battery     = node->create_publisher<sensor_msgs::msg::BatteryState>("/whill/states/batttery_state", 10);
+	auto whill_modelc_odom        = node->create_publisher<nav_msgs::msg::Odometry>("/whill/odom", 10);
 
 	auto clear_odom_srv           = node->create_service<std_srvs::srv::Empty>("/whill/odom/clear", clearOdom);
 	
-	auto whill_speed_profile      = node->create_publisher<ros2_whill_interfaces::msg::WhillSpeedProfile>("/whill/speed_profile");
+	auto whill_speed_profile      = node->create_publisher<ros2_whill_interfaces::msg::WhillSpeedProfile>("/whill/speed_profile", 10);
 
 	tf2_ros::TransformBroadcaster odom_broadcaster_(node);
 
@@ -220,10 +220,10 @@ int main(int argc, char **argv)
 			msg_sp->ra1 = int(recv_buf[6] & 0xff);
 			msg_sp->rd1 = int(recv_buf[7] & 0xff);
 			msg_sp->tm1 = int(recv_buf[8] & 0xff);
-			msg_sp->ta1 = int(recv_buf[9] & 0xff);
-			msg_sp->td1 = int(recv_buf[10] & 0xff);
-			whill_speed_profile->publish(msg_sp);
-			RCLCPP_INFO(node->get_logger(), "Speed profile %ld is published", msg_sp->s1);
+		msg_sp->ta1 = int(recv_buf[9] & 0xff);
+		msg_sp->td1 = int(recv_buf[10] & 0xff);
+		whill_speed_profile->publish(*msg_sp);
+		RCLCPP_INFO(node->get_logger(), "Speed profile %ld is published", msg_sp->s1);
 		}
 	}
 
@@ -352,48 +352,54 @@ int main(int argc, char **argv)
 					
 					joy->axes.resize(2);
 					joy->axes[0] = -msg->joy_side / 100.0f; //X
-					joy->axes[1] = msg->joy_front  / 100.0f; //Y
+				joy->axes[1] = msg->joy_front  / 100.0f; //Y
 
 
-					// JointState message
-					jointState->name.resize(2);
-					jointState->position.resize(2);
-					jointState->velocity.resize(2);
+				// JointState message
+				jointState->name.resize(2);
+				jointState->position.resize(2);
+				jointState->velocity.resize(2);
 
-					jointState->name[0]     = "leftWheel";
-					jointState->position[0] = msg->left_motor_angle;  //Rad
+				jointState->name[0]     = "leftWheel";
+				jointState->position[0] = msg->left_motor_angle;  //Rad
+				jointState->name[1]     = "rightWheel";
+				jointState->position[1] = msg->right_motor_angle;  //Rad
 
-					static double past[2] = {0.0f,0.0f};
-					
-					if(time_diff_ms != 0)jointState->velocity[0] = calc_rad_diff(past[0],jointState->position[0]) / (double(time_diff_ms) / 1000.0f);
-					else jointState->velocity[0] = 0;
-
+				static double past[2] = {0.0f,0.0f};
+				static bool is_first_data = true;
+				
+				if(is_first_data) {
+					// 初回は速度を0とし、現在位置を初期値として設定
+					jointState->velocity[0] = 0.0;
+					jointState->velocity[1] = 0.0;
 					past[0] = jointState->position[0];
-
-					jointState->name[1]     = "rightWheel";
-					jointState->position[1] = msg->right_motor_angle;  //Rad
-
-					if(time_diff_ms != 0)jointState->velocity[1] = calc_rad_diff(past[1],jointState->position[1]) / (double(time_diff_ms) / 1000.0f);
-					else jointState->velocity[0] = 0;
 					past[1] = jointState->position[1];
+					is_first_data = false;
+				} else {
+					// 2回目以降は正常に速度を計算
+					if(time_diff_ms != 0) {
+						jointState->velocity[0] = calc_rad_diff(past[0],jointState->position[0]) / (double(time_diff_ms) / 1000.0f);
+						jointState->velocity[1] = calc_rad_diff(past[1],jointState->position[1]) / (double(time_diff_ms) / 1000.0f);
+					} else {
+						jointState->velocity[0] = 0;
+						jointState->velocity[1] = 0;
+					}
+					past[0] = jointState->position[0];
+					past[1] = jointState->position[1];
+				}
 
-
-					odom.update(*jointState, time_diff_ms/1000.0f);
-					
-
+				odom.update(*jointState, time_diff_ms/1000.0f);
 					msg->error = int(recv_buf[28] & 0xff);
 					if(msg->error != 0)
 					{
 						RCLCPP_WARN(node->get_logger(), "WHILL sends error message. error id: %d", msg->error);
 					}
 
-					// publish
-					whill_modelc_joy->publish(joy);
-					whill_modelc_joint_state->publish(jointState);
-					whill_modelc_imu->publish(imu);
-					whill_modelc_battery->publish(batteryState);
-
-					// Publish Odometry
+				// publish
+				whill_modelc_joy->publish(*joy);
+				whill_modelc_joint_state->publish(*jointState);
+				whill_modelc_imu->publish(*imu);
+				whill_modelc_battery->publish(*batteryState);					// Publish Odometry
 					auto odom_trans = std::make_shared<geometry_msgs::msg::TransformStamped>();
 					*odom_trans = odom.getROSTransformStamped();
 					odom_trans->header.stamp.sec = RCL_NS_TO_S(now);
@@ -402,20 +408,19 @@ int main(int argc, char **argv)
 					odom_trans->child_frame_id = "base_footprint";
 					odom_broadcaster_.sendTransform(*odom_trans);
 
-					auto odom_msg = std::make_shared<nav_msgs::msg::Odometry>();
-					*odom_msg = odom.getROSOdometry();
-					odom_msg->header.stamp.sec = RCL_NS_TO_S(now);
-					odom_msg->header.stamp.nanosec = now - RCL_S_TO_NS(odom_msg->header.stamp.sec);
-					odom_msg->header.frame_id = "odom";
-					odom_msg->child_frame_id = "base_footprint";
-					whill_modelc_odom->publish(odom_msg);
-				}
+
+				auto odom_msg = std::make_shared<nav_msgs::msg::Odometry>();
+				*odom_msg = odom.getROSOdometry();
+				odom_msg->header.stamp.sec = RCL_NS_TO_S(now);
+				odom_msg->header.stamp.nanosec = now - RCL_S_TO_NS(odom_msg->header.stamp.sec);
+				odom_msg->header.frame_id = "odom";
+				odom_msg->child_frame_id = "base_footprint";
+				whill_modelc_odom->publish(*odom_msg);
 			}
 		}
+	}
 
-		rclcpp::spin_some(node);
-		
-
+	rclcpp::spin_some(node);
 	}
 
 	// send StopSendingData command


### PR DESCRIPTION
## Description
This PR updates the `crystal-devel` branch to support ROS 2 Humble, specifically for **WHILL Model CR** users.

While there is an existing `humble` branch in this repository, it does not fully support Model CR-specific features (such as **Odometry** retrieval) that were available in the `crystal` version. Therefore, I ported the `crystal` version to Humble to restore these capabilities for Model CR.

Additionally, I added support for velocity control via `cmd_vel` (geometry_msgs/Twist), enabling integration with the Navigation2 stack.

## Changes
* **Ported Model CR features to Humble:** Enabled full Model CR functionality (e.g., Odometry) on ROS 2 Humble (Ubuntu 22.04), which is missing in the current `humble` branch.
* **Added cmd_vel support:** Added a subscriber for `cmd_vel` to control linear and angular velocity.
* **Verified operation:** Verified operation with real WHILL Model CR hardware.

## Note regarding branching
I chose `crystal-devel` as the base because the current `humble` branch lacks support for Model CR-specific functions (e.g., Odometry). Please let me know if there is a better branch target for this update.